### PR TITLE
Why are the checks in safe divide commented out?

### DIFF
--- a/MainSale.sol
+++ b/MainSale.sol
@@ -12,9 +12,9 @@ library SafeMath {
   }
 
   function div(uint256 a, uint256 b) internal constant returns (uint256) {
-    // assert(b > 0); // Solidity automatically throws when dividing by 0
+    assert(b > 0); // Solidity automatically throws when dividing by 0
     uint256 c = a / b;
-    // assert(a == b * c + a % b); // There is no case in which this doesn't hold
+    assert(a == b * c + a % b); // There is no case in which this doesn't hold
     return c;
   }
 


### PR DESCRIPTION
I know the rest of this file doesn't use the divide method but it would be awful easy to forget and I don't see why they should be commented out.